### PR TITLE
Exported the Categorical distribution type.

### DIFF
--- a/random-fu/src/Data/Random/Distribution/Categorical.hs
+++ b/random-fu/src/Data/Random/Distribution/Categorical.hs
@@ -54,7 +54,7 @@ toList (Categorical ds) = V.foldr' g [] ds
 
 -- |Construct a 'Categorical' distribution from a list of weighted categories, 
 -- where the weights do not necessarily sum to 1.
-fromWeightedList :: (Fractional p, Ord a) => [(p,a)] -> Categorical p a
+fromWeightedList :: Fractional p => [(p,a)] -> Categorical p a
 fromWeightedList = normalizeCategoricalPs . fromList
 
 -- |Construct a 'Categorical' distribution from a list of observed outcomes.
@@ -77,6 +77,12 @@ instance (Num p, Show a) => Show (Categorical p a) where
         ( showString "fromList "
         . showsPrec 11 (toList cat)
         )
+
+instance (Num p, Read p, Read a) => Read (Categorical p a) where
+  readsPrec p = readParen (p > 10) $ \str -> do
+                  ("fromList", valStr) <- lex str
+                  (vals,       rest)   <- readsPrec 11 valStr
+                  return (fromList vals, rest)
 
 instance (Fractional p, Ord p, Distribution Uniform p) => Distribution (Categorical p) a where
     rvarT (Categorical ds)


### PR DESCRIPTION
This was the only distribution whose data type wasn't exported, so I made things more regular.  I exported the constructor as well, since the rest of the types have exported constructors.

I actually just needed this in a project I'm working on; as it stands, you can't declare a data type which has a field whose type is `Categorical p a`.
