### PR TITLE
Add Show and Eq constraints

### DIFF
--- a/random-fu/src/Data/Random/Distribution/Beta.hs
+++ b/random-fu/src/Data/Random/Distribution/Beta.hs
@@ -16,7 +16,7 @@ import Data.Random.Distribution.Uniform
 
 {-# SPECIALIZE fractionalBeta :: Float  -> Float  -> RVarT m Float #-}
 {-# SPECIALIZE fractionalBeta :: Double -> Double -> RVarT m Double #-}
-fractionalBeta :: (Fractional a, Distribution Gamma a, Distribution StdUniform a) => a -> a -> RVarT m a
+fractionalBeta :: (Fractional a, Eq a, Distribution Gamma a, Distribution StdUniform a) => a -> a -> RVarT m a
 fractionalBeta 1 1 = stdUniformT
 fractionalBeta a b = do
     x <- gammaT a 1

--- a/random-fu/src/Data/Random/Distribution/Categorical.hs
+++ b/random-fu/src/Data/Random/Distribution/Categorical.hs
@@ -54,14 +54,14 @@ toList (Categorical ds) = V.foldr' g [] ds
 
 -- |Construct a 'Categorical' distribution from a list of weighted categories, 
 -- where the weights do not necessarily sum to 1.
-fromWeightedList :: Fractional p => [(p,a)] -> Categorical p a
+fromWeightedList :: (Fractional p, Eq p) => [(p,a)] -> Categorical p a
 fromWeightedList = normalizeCategoricalPs . fromList
 
 -- |Construct a 'Categorical' distribution from a list of observed outcomes.
 -- Equivalent events will be grouped and counted, and the probabilities of each
 -- event in the returned distribution will be proportional to the number of 
 -- occurrences of that event.
-fromObservations :: (Fractional p, Ord a) => [a] -> Categorical p a
+fromObservations :: (Fractional p, Eq p, Ord a) => [a] -> Categorical p a
 fromObservations = fromWeightedList . map (genericLength &&& head) . group . sort
 
 -- The following description refers to the public interface.  For those reading
@@ -78,7 +78,7 @@ fromObservations = fromWeightedList . map (genericLength &&& head) . group . sor
 newtype Categorical p a = Categorical (V.Vector (p, a))
     deriving Eq
 
-instance (Num p, Show a) => Show (Categorical p a) where
+instance (Num p, Show p, Show a) => Show (Categorical p a) where
     showsPrec p cat = showParen (p>10)
         ( showString "fromList "
         . showsPrec 11 (toList cat)
@@ -170,7 +170,7 @@ mapCategoricalPs f (Categorical ds) = Categorical (V.map (first f) ds)
 
 -- |Adjust all the weights of a categorical distribution so that they 
 -- sum to unity and remove all events whose probability is zero.
-normalizeCategoricalPs :: (Fractional p) => Categorical p e -> Categorical p e
+normalizeCategoricalPs :: (Fractional p, Eq p) => Categorical p e -> Categorical p e
 normalizeCategoricalPs orig@(Categorical ds) = 
     if V.null ds
         then orig

--- a/random-fu/src/Data/Random/Distribution/Multinomial.hs
+++ b/random-fu/src/Data/Random/Distribution/Multinomial.hs
@@ -14,7 +14,7 @@ multinomialT ps n = rvarT (Multinomial ps n)
 data Multinomial p a where
     Multinomial :: [p] -> a -> Multinomial p [a]
 
-instance (Num a, Fractional p, Distribution (Binomial p) a) => Distribution (Multinomial p) [a] where
+instance (Num a, Eq a, Fractional p, Distribution (Binomial p) a) => Distribution (Multinomial p) [a] where
     -- TODO: implement faster version based on Categorical for small n, large (length ps)
     rvarT (Multinomial ps0 t) = go t ps0 (tailSums ps0) id
         where

--- a/random-fu/src/Data/Random/Distribution/Rayleigh.hs
+++ b/random-fu/src/Data/Random/Distribution/Rayleigh.hs
@@ -10,7 +10,7 @@ import Data.Random.RVar
 import Data.Random.Distribution
 import Data.Random.Distribution.Uniform
 
-floatingRayleigh :: (Floating a, Distribution StdUniform a) => a -> RVarT m a
+floatingRayleigh :: (Floating a, Eq a, Distribution StdUniform a) => a -> RVarT m a
 floatingRayleigh s = do
     u <- stdUniformPosT
     return (s * sqrt (-2 * log u))

--- a/random-fu/src/Data/Random/Distribution/Uniform.hs
+++ b/random-fu/src/Data/Random/Distribution/Uniform.hs
@@ -246,15 +246,15 @@ stdUniformT = rvarT StdUniform
 -- |Like 'stdUniform', but returns only positive or zero values.  Not 
 -- exported because it is not truly uniform: nonzero values are twice
 -- as likely as zero on signed types.
-stdUniformNonneg :: (Distribution StdUniform a, Num a) => RVarT m a
+stdUniformNonneg :: (Distribution StdUniform a, Num a, Eq a) => RVarT m a
 stdUniformNonneg = fmap abs stdUniformT
 
 -- |Like 'stdUniform' but only returns positive values.
-stdUniformPos :: (Distribution StdUniform a, Num a) => RVar a
+stdUniformPos :: (Distribution StdUniform a, Num a, Eq a) => RVar a
 stdUniformPos = stdUniformPosT
 
 -- |Like 'stdUniform' but only returns positive values.
-stdUniformPosT :: (Distribution StdUniform a, Num a) => RVarT m a
+stdUniformPosT :: (Distribution StdUniform a, Num a, Eq a) => RVarT m a
 stdUniformPosT = iterateUntil (/= 0) stdUniformNonneg
 
 -- |A definition of a uniform distribution over the type @t@.  See also 'uniform'.


### PR DESCRIPTION
Num no longer carries Show and Eq constraints as of ghc 7.4. Add these
explicitly.
