### PR TITLE
Add specific instance for Lift for Identity

### DIFF
--- a/random-fu/src/Data/Random/Lift.hs
+++ b/random-fu/src/Data/Random/Lift.hs
@@ -43,6 +43,9 @@ instance Monad m => Lift T.Identity m where
 instance Lift (RVarT T.Identity) (RVarT m) where
     lift x = runRVar x StdRandom
 
+instance T.MonadTrans t => Lift T.Identity (t T.Identity) where
+  lift = T.lift
+
 #ifndef MTL2
 
 -- | This instance is incoherent with the other two. However,


### PR DESCRIPTION
I have added a specific instance for Lift that fixes things up when there is no overlapping instance that is more specific. See the following SO post for discussion:

http://stackoverflow.com/questions/14096742/extracting-random-items-from-a-sequence/14123327#14123327
