### PR TITLE
Document `Data.Random.Distribution.Exponential`

### DIFF
--- a/random-fu/src/Data/Random/Distribution/Exponential.hs
+++ b/random-fu/src/Data/Random/Distribution/Exponential.hs
@@ -10,6 +10,15 @@ import Data.Random.RVar
 import Data.Random.Distribution
 import Data.Random.Distribution.Uniform
 
+{-|
+A definition of the exponential distribution over the type @a@.
+
+@'Exp' mu@ models an exponential distribution with mean @mu@. This can
+alternatively be viewed as an exponential distribution with parameter @lambda =
+1 / mu@.
+
+See also 'exponential'.
+-}
 newtype Exponential a = Exp a
 
 floatingExponential :: (Floating a, Distribution StdUniform a) => a -> RVarT m a
@@ -20,9 +29,23 @@ floatingExponential lambdaRecip = do
 floatingExponentialCDF :: Real a => a -> a -> Double
 floatingExponentialCDF lambdaRecip x = 1 - exp (negate (realToFrac x) / realToFrac lambdaRecip)
 
+{-|
+A random variable which samples from the exponential distribution.
+
+@'exponential' mu@ is an exponential random variable with mean @mu@. This can
+alternatively be viewed as an exponential random variable with parameter @lambda
+= 1 / mu@.
+-}
 exponential :: Distribution Exponential a => a -> RVar a
 exponential = rvar . Exp
 
+{-|
+A random variable transformer which samples from the exponential distribution.
+
+@'exponentialT' mu@ is an exponential random variable with mean @mu@. This can
+alternatively be viewed as an exponential random variable with parameter @lambda
+= 1 / mu@.
+-}
 exponentialT :: Distribution Exponential a => a -> RVarT m a
 exponentialT = rvarT . Exp
 


### PR DESCRIPTION
I used `random-fu` to simulate a random process for some university work, as a means to verify an analytic solution of the same process. I was very confused for a long time because I assumed the `exponential` function accepted parameter `lambda`, rather the mean, `1 / lambda`. Here's some documentation so that doesn't happen to anyone else!