### PR TITLE
remove erf-native dependency under Windows

### DIFF
--- a/random-fu/random-fu.cabal
+++ b/random-fu/random-fu.cabal
@@ -98,13 +98,8 @@ Library
                         template-haskell,
                         transformers,
                         vector >= 0.7,
-                        log-domain >=0.9 && <1.0
-
-  if os(Windows)
-    cpp-options:        -Dwindows
-    build-depends:      erf-native
-  else
-    build-depends:      erf
+                        log-domain >=0.9 && <1.0,
+                        erf
   
   if impl(ghc == 7.2.1)
     -- Doesn't work under GHC 7.2.1 due to


### PR DESCRIPTION
erf builds fine under Windows (Windows 10, Stack 1.4.0, lts-8-9, GHC installed by stack). erf-native does not, at least under stack / lts-8-9