### PR TITLE
Add MonadRandom instances for RWS.

### DIFF
--- a/random-source/src/Data/Random/Source/PureMT.hs
+++ b/random-source/src/Data/Random/Source/PureMT.hs
@@ -25,7 +25,9 @@ module Data.Random.Source.PureMT
     ) where
 
 import Control.Monad.State
+import Control.Monad.RWS
 import qualified Control.Monad.State.Strict as S
+import qualified Control.Monad.RWS.Strict as S
 import Data.Random.Internal.Source
 import Data.Random.Source.Internal.TH
 import Data.StateRef
@@ -58,6 +60,18 @@ $(monadRandom
             getRandomDouble = withMTState randomDouble
      |])
 
+$(monadRandom
+    [d| instance Monoid w => MonadRandom (RWS r w PureMT) where
+            getRandomWord64 = withMTState randomWord64
+            getRandomDouble = withMTState randomDouble
+     |])
+
+$(monadRandom
+    [d| instance Monoid w => MonadRandom (S.RWS r w PureMT) where
+            getRandomWord64 = withMTState randomWord64
+            getRandomDouble = withMTState randomDouble
+     |])
+
 #endif
 
 $(randomSource
@@ -74,6 +88,18 @@ $(monadRandom
 
 $(monadRandom
     [d| instance Monad m => MonadRandom (S.StateT PureMT m) where
+            getRandomWord64 = withMTState randomWord64
+            getRandomDouble = withMTState randomDouble
+     |])
+
+$(monadRandom
+    [d| instance (Monad m, Monoid w) => MonadRandom (RWST r w PureMT m) where
+            getRandomWord64 = withMTState randomWord64
+            getRandomDouble = withMTState randomDouble
+     |])
+
+$(monadRandom
+    [d| instance (Monad m, Monoid w) => MonadRandom (S.RWST r w PureMT m) where
             getRandomWord64 = withMTState randomWord64
             getRandomDouble = withMTState randomDouble
      |])

--- a/random-source/src/Data/Random/Source/StdGen.hs
+++ b/random-source/src/Data/Random/Source/StdGen.hs
@@ -24,8 +24,10 @@ module Data.Random.Source.StdGen
 import Data.Random.Internal.Source
 import System.Random
 import Control.Monad.State
+import Control.Monad.RWS
 import qualified Control.Monad.ST.Strict as S
 import qualified Control.Monad.State.Strict as S
+import qualified Control.Monad.RWS.Strict as S
 import Data.StateRef
 import Data.Word
 
@@ -119,6 +121,12 @@ instance MonadRandom (State StdGen) where
 
 instance MonadRandom (S.State StdGen) where
     getRandomPrim = getRandomPrimFromRandomGenState
+
+instance Monoid w => MonadRandom (RWS r w StdGen) where
+    getRandomPrim = getRandomPrimFromRandomGenState
+
+instance Monoid w => MonadRandom (S.RWS r w StdGen) where
+    getRandomPrim = getRandomPrimFromRandomGenState
 #endif
 
 instance Monad m => MonadRandom (StateT StdGen m) where
@@ -127,3 +135,8 @@ instance Monad m => MonadRandom (StateT StdGen m) where
 instance Monad m => MonadRandom (S.StateT StdGen m) where
     getRandomPrim = getRandomPrimFromRandomGenState
 
+instance (Monad m, Monoid w) => MonadRandom (RWST r w StdGen m) where
+    getRandomPrim = getRandomPrimFromRandomGenState
+
+instance (Monad m, Monoid w) => MonadRandom (S.RWST r w StdGen m) where
+    getRandomPrim = getRandomPrimFromRandomGenState


### PR DESCRIPTION
`random-source` defines `MonadRandom` instances for `State StdGen` (and `StateT StdGen m`), but not for `RWS r w StdGen` (nor `RWST r w StdGen m`).  This pull request adds these instances by simple copying and pasting.