### PR TITLE
Add support for GHC 8.8

### DIFF
--- a/random-fu/src/Data/Random/Distribution/Categorical.hs
+++ b/random-fu/src/Data/Random/Distribution/Categorical.hs
@@ -112,7 +112,7 @@ instance (Num p, Read p, Read a) => Read (Categorical p a) where
 
 instance (Fractional p, Ord p, Distribution Uniform p) => Distribution (Categorical p) a where
     rvarT (Categorical ds)
-        | V.null ds = fail "categorical distribution over empty set cannot be sampled"
+        | V.null ds = error "categorical distribution over empty set cannot be sampled"
         | n == 1    = return (snd (V.head ds))
         | otherwise = do
             u <- uniformT 0 (fst (V.last ds))
@@ -158,7 +158,9 @@ instance Fractional p => Monad (Categorical p) where
     
     -- I'm not entirely sure whether this is a valid form of failure; see next
     -- set of comments.
+#if __GLASGOW_HASKELL__ < 808
     fail _ = Categorical V.empty
+#endif
     
     -- Should the normalize step be included here, or should normalization
     -- be assumed?  It seems like there is (at least) 1 valid situation where

--- a/random-fu/src/Data/Random/Distribution/ChiSquare.hs
+++ b/random-fu/src/Data/Random/Distribution/ChiSquare.hs
@@ -22,7 +22,7 @@ instance (Fractional t, Distribution Gamma t) => Distribution ChiSquare t where
     rvarT (ChiSquare 0) = return 0
     rvarT (ChiSquare n)
         | n > 0     = gammaT (0.5 * fromInteger n) 2
-        | otherwise = fail "chi-square distribution: degrees of freedom must be positive"
+        | otherwise = error "chi-square distribution: degrees of freedom must be positive"
 
 instance (Real t, Distribution ChiSquare t) => CDF ChiSquare t where
     cdf (ChiSquare n) x = incompleteGamma (0.5 * fromInteger n) (0.5 * realToFrac x)

--- a/random-fu/src/Data/Random/Distribution/T.hs
+++ b/random-fu/src/Data/Random/Distribution/T.hs
@@ -34,7 +34,7 @@ instance (Floating a, Distribution Normal a, Distribution ChiSquare a) => Distri
             x <- stdNormalT
             y <- chiSquareT n
             return (x * sqrt (fromInteger n / y))
-        | otherwise = fail "Student's t-distribution: degrees of freedom must be positive"
+        | otherwise = error "Student's t-distribution: degrees of freedom must be positive"
 
 instance (Real a, Distribution T a) => CDF T a where
     cdf (T n) t = incompleteBeta v2 v2 x

--- a/rvar/src/Data/RVar.hs
+++ b/rvar/src/Data/RVar.hs
@@ -197,7 +197,6 @@ instance Functor (RVarT n) where
 
 instance Monad (RVarT n) where
     return x = RVarT (return $! x)
-    fail s   = RVarT (fail s)
     (RVarT m) >>= k = RVarT (m >>= \x -> x `seq` unRVarT (k x))
 
 instance MonadRandom (RVarT n) where


### PR DESCRIPTION
GHC 8.8 implements the final step in the MonadFail proposal by removing
`fail` from the `Monad` class and instead exposing the MonadFail class.
