### PR TITLE
Remove dependency on log-domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Icon?
 ###########
 
 dist
+dist-newstyle
 *.o
 *.hi
 *.chi

--- a/random-fu/changelog.md
+++ b/random-fu/changelog.md
@@ -1,4 +1,4 @@
-* Changes in 0.2.7.2: Remove dependence on log-domain. Raise lower bound for base to 4.9.
+* Changes in 0.2.7.3: Remove dependence on log-domain. Raise lower bound for base to 4.9.
 
 * Changes in 0.2.7.1: Add PDF instance for Poisson.
 

--- a/random-fu/changelog.md
+++ b/random-fu/changelog.md
@@ -1,3 +1,5 @@
+* Changes in 0.2.7.2: Remove dependence on log-domain. Raise lower bound for base to 4.9.
+
 * Changes in 0.2.7.1: Add PDF instance for Poisson.
 
 * Changes in 0.2.7.0: Add Simplex, fix logBetaPdf, fix binomialPdf and

--- a/random-fu/random-fu.cabal
+++ b/random-fu/random-fu.cabal
@@ -1,5 +1,5 @@
 name:                   random-fu
-version:                0.2.7.2
+version:                0.2.7.3
 stability:              provisional
 
 cabal-version:          >= 1.6
@@ -78,7 +78,7 @@ Library
                         Data.Random.Sample
                         Data.Random.Vector
   if flag(base4_2)
-    build-depends:      base >= 4.2 && <5
+    build-depends:      base >= 4.9 && <5
   else
     cpp-options:        -Dold_Fixed
     build-depends:      base >= 4 && <4.2
@@ -98,7 +98,6 @@ Library
                         template-haskell,
                         transformers,
                         vector >= 0.7,
-                        log-domain >=0.9 && <1.0,
                         erf
   
   if impl(ghc == 7.2.1)

--- a/random-fu/src/Data/Random/Distribution/Binomial.hs
+++ b/random-fu/src/Data/Random/Distribution/Binomial.hs
@@ -16,7 +16,7 @@ import Data.Random.Distribution.Uniform
 
 import Numeric.SpecFunctions ( stirlingError )
 import Numeric.SpecFunctions.Extra ( bd0 )
-import Numeric.Log ( log1p )
+import Numeric ( log1p )
 
     -- algorithm from Knuth's TAOCP, 3rd ed., p 136
     -- specific choice of cutoff size taken from gsl source


### PR DESCRIPTION
-Removed dependency on log-domain (in Binomial.hs) since ```log1p``` now in base>= 4.9.
-Raised lower bound on base accordingly.  
-Updated random-fu/changelog.md
-added "dist-newstyle" to .gitignore for new-style cabal builds